### PR TITLE
Updates for Elm 0.19

### DIFF
--- a/ElmAsset.js
+++ b/ElmAsset.js
@@ -9,7 +9,6 @@ class ElmAsset extends JSAsset {
 
   getParserOptions() {
     const defaultOptions = {
-      yes: true,
       cwd: process.cwd(),
     };
     return defaultOptions;

--- a/ElmAsset.js
+++ b/ElmAsset.js
@@ -1,7 +1,5 @@
 const elmCompiler = require('node-elm-compiler');
-const findAllDependencies = require("find-elm-dependencies").findAllDependencies;
-const fs = require('fs');
-const path = require('path');
+const { findAllDependencies } = require('find-elm-dependencies');
 const process = require('process');
 const JSAsset = require('parcel-bundler/src/assets/JSAsset');
 
@@ -18,7 +16,7 @@ class ElmAsset extends JSAsset {
     };
     return defaultOptions;
   }
-  
+
   async getDependencies() {
     await super.getDependencies()
     let deps = await findAllDependencies(this.name);

--- a/ElmAsset.js
+++ b/ElmAsset.js
@@ -10,6 +10,11 @@ class ElmAsset extends JSAsset {
   getParserOptions() {
     const defaultOptions = {
       cwd: process.cwd(),
+
+      // IMPORTANT NOTE: We'll run with the `--optimize` flag if `NODE_ENV` is
+      // set to production
+      optimize: (process.env.NODE_ENV === 'production'),
+
     };
     return defaultOptions;
   }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = function(bundler) {
     bundler.addAssetType('elm', require.resolve('./ElmAsset'));
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-elm",
-  "version": "0.1.3-alpha",
+  "version": "0.2.0-alpha",
   "description": "A parcel plugin that enables elm support",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "author": "Suman Subash",
   "license": "ISC",
   "dependencies": {
-    "find-elm-dependencies": "^1.0.2",
-    "node-elm-compiler": "^4.4.1",
+    "find-elm-dependencies": "^2.0.0",
+    "node-elm-compiler": "^5.0.1",
     "parcel-bundler": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
A few small updates so that this package will work with Elm 0.19.

* Updated dependencies:
    * `node-elm-compiler`
    * `find-elm-dependencies`
* Removed outdated `yes` parser option (per `node-elm-compiler`)
* Run with optimize flag if `process.env.NODE_ENV == 'production'`

Note that this update will not be backwards compatible with Elm 0.18 (but I'm totally open to suggestions if that's important to anyone).